### PR TITLE
Remove leftover git instructions

### DIFF
--- a/fbpost-checker-deploy/.gitignore
+++ b/fbpost-checker-deploy/.gitignore
@@ -62,12 +62,3 @@ OneDrive/
 Music/
 Desktop/
 Dropbox/
-# เพิ่ม .gitignore เข้า git
-git add .gitignore
-
-# commit การเปลี่ยนแปลง
-git commit -m "Update .gitignore to exclude system and build files"
-
-# push ขึ้น GitHub
-git push
-


### PR DESCRIPTION
## Summary
- clean up `.gitignore` in deploy directory by removing git command reminders

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6870f1c9a918832ead5ea4633a154520