### PR TITLE
Add Jest test for backup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+        working-directory: fbpost-checker-deploy
+      - name: Run tests
+        run: npm test
+        working-directory: fbpost-checker-deploy
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/fbpost-checker-deploy/package-lock.json
+++ b/fbpost-checker-deploy/package-lock.json
@@ -6,6 +6,9 @@
     "": {
       "dependencies": {
         "archiver": "^7.0.1"
+      },
+      "devDependencies": {
+        "jest": "^29.7.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/fbpost-checker-deploy/package.json
+++ b/fbpost-checker-deploy/package.json
@@ -5,9 +5,13 @@
   "main": "index.js",
   "scripts": {
     "backup": "node backup.js",
-    "deploy": "npm run backup && firebase deploy"
+    "deploy": "npm run backup && firebase deploy",
+    "test": "jest"
   },
   "dependencies": {
     "archiver": "^7.0.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/fbpost-checker-deploy/test/backup.test.js
+++ b/fbpost-checker-deploy/test/backup.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+
+describe('backup script', () => {
+  test('creates a zip including the sample file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'backup-test-'));
+    // copy backup.js into temp directory so __dirname matches
+    const scriptSrc = path.join(__dirname, '..', 'backup.js');
+    const scriptDest = path.join(tmpDir, 'backup.js');
+    fs.copyFileSync(scriptSrc, scriptDest);
+
+    // create public directory and sample file
+    const publicDir = path.join(tmpDir, 'public');
+    fs.mkdirSync(publicDir);
+    const sampleFile = path.join(publicDir, 'sample.txt');
+    fs.writeFileSync(sampleFile, 'sample');
+
+    // run the backup script
+    const result = spawnSync('node', ['backup.js'], { cwd: tmpDir, encoding: 'utf8' });
+    expect(result.status).toBe(0);
+
+    // check that a zip file exists in backups
+    const backupsDir = path.join(tmpDir, 'backups');
+    const zips = fs.readdirSync(backupsDir).filter(f => f.endsWith('.zip'));
+    expect(zips.length).toBe(1);
+    const zipPath = path.join(backupsDir, zips[0]);
+
+    // verify the sample file is inside the zip
+    const list = spawnSync('unzip', ['-l', zipPath], { encoding: 'utf8' });
+    expect(list.status).toBe(0);
+    expect(list.stdout).toMatch(/sample.txt/);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test for backup script
- install Jest and expose `npm test`
- run tests in CI before deploying

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f92acf9c832ea3e5147bccf20dfe